### PR TITLE
Update doit formula to v0.10.2

### DIFF
--- a/doit.rb
+++ b/doit.rb
@@ -2,29 +2,29 @@ class Doit < Formula
   desc "A CLI progress monitor for time-based visualization"
   homepage "https://github.com/matsuokashuhei/doit"
   license "MIT"
-  version "0.10.1"
+  version "0.10.2"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.1/doit-macos-x86_64"
-      sha256 "c3efeff3ce32b4cd061419a3922a3845c803a86987a0b9b822e130161bea7898"
+      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.2/doit-macos-x86_64"
+      sha256 "6b87873a400e81d2f447f47ffd8fc8f41bddb85c23ba7bf8152ca70d68520cff"
     end
 
     if Hardware::CPU.arm?
-      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.1/doit-macos-aarch64"
-      sha256 "33c070079105704e55c04f3a20a6e8821c49dea6d31cf5ac1593345353b45e9d"
+      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.2/doit-macos-aarch64"
+      sha256 "4ddd29f5db8e8df8990abf09533b8a50e0f22b50ae586dba1af4c6325f70ca79"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.1/doit-linux-x86_64"
-      sha256 "586b8766fbaccc59685ba0251939585348fec12a7b589c6c950be4444caed728"
+      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.2/doit-linux-x86_64"
+      sha256 "3d5b14f599d4170cc6995c9fcb2902baeeeaae30f83bbd72a4114ad215a63acc"
     end
 
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.1/doit-linux-aarch64"
-      sha256 "197c73fe7ad52abcdbf29715f419e4bbdac7db4017451c225132be85ad037cc8"
+      url "https://github.com/matsuokashuhei/doit/releases/download/v0.10.2/doit-linux-aarch64"
+      sha256 "83df9d7186674d3b59f6d2df0179f8158af38f79006106b85457e3031efc7069"
     end
   end
 


### PR DESCRIPTION
## Summary

Updates the doit Homebrew formula to version 0.10.2 with new release assets and SHA256 hashes.

## Changes

- **Version**: Updated from 0.10.1 to 0.10.2
- **URLs**: Updated to point to v0.10.2 release assets for all platforms
- **SHA256 Hashes**: Updated for all platform binaries:
  - **macOS Intel (x86_64)**: `6b87873a400e81d2f447f47ffd8fc8f41bddb85c23ba7bf8152ca70d68520cff`
  - **macOS Apple Silicon (aarch64)**: `4ddd29f5db8e8df8990abf09533b8a50e0f22b50ae586dba1af4c6325f70ca79`
  - **Linux Intel (x86_64)**: `3d5b14f599d4170cc6995c9fcb2902baeeeaae30f83bbd72a4114ad215a63acc`
  - **Linux ARM64 (aarch64)**: `83df9d7186674d3b59f6d2df0179f8158af38f79006106b85457e3031efc7069`

## What's New in v0.10.2

- **Bug Fix**: Fixed interval option range validation to allow exactly 60 seconds
- **Testing**: Added comprehensive test cases for interval validation
- **Technical**: Changed validation from `1..60` (exclusive) to `1..=60` (inclusive)

## Verification

All SHA256 hashes have been verified against the release assets from:
https://github.com/matsuokashuhei/doit/releases/tag/v0.10.2

The release assets were built and uploaded automatically via GitHub Actions.